### PR TITLE
fix zufardhiyaulhaq repository

### DIFF
--- a/config-map.yaml
+++ b/config-map.yaml
@@ -1163,6 +1163,6 @@ data:
       },
       {
         "name":"zufardhiyaulhaq",
-        "url":"https://charts.zufardhiyaulhaq.com/"
+        "url":"https://charts.zufardhiyaulhaq.com"
       }
     ]


### PR DESCRIPTION
current code is using URL with logic
```
url key + /index.yaml
```

somehow chartmuseum is not accepting `//index.yaml`. We need to standardize the URL or add some logic to remove duplicate slash (/).